### PR TITLE
Conan definition for Celero v2.1.1

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,39 @@
+from conans import ConanFile, CMake
+
+
+class CeleroConan(ConanFile):
+    name = "Celero"
+    version = "2.1.1"
+    license = "Apache License Version 2.0"
+    url = "https://github.com/DigitalInBlue/Celero-Conan"
+    description = "C++ Benchmark Authoring Library/Framework"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False]}
+    default_options = "shared=True"
+    generators = "cmake"
+
+    def source(self):
+        gitRepo = "https://github.com/DigitalInBlue/Celero.git"
+        commitID = "v2.1.1"
+        self.run("git init")
+        self.run("git fetch %s %s" % (gitRepo,commitID))
+        self.run("git reset --hard FETCH_HEAD")
+
+    def build(self):
+        cmake = CMake(self)
+        if self.options.shared:
+            cmake.definitions["CELERO_COMPILE_DYNAMIC_LIBRARIES"] = "ON"
+        else:
+            cmake.definitions["CELERO_COMPILE_DYNAMIC_LIBRARIES"] = "OFF"
+        cmake.definitions["CELERO_ENABLE_EXPERIMENTS"] = "OFF"
+        cmake.definitions["CELERO_ENABLE_FOLDERS"] = "OFF"
+        cmake.configure()
+        cmake.build(target="celero")
+        cmake.install()
+
+    def package(self):
+        self.copy("*", src="package")
+
+    def package_info(self):
+        self.cpp_info.libs = ["celero"]
+        self.cpp_info.libdirs = ["lib","lib/static","bin"]

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(PackageTest CXX)
+cmake_minimum_required(VERSION 2.8.12)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+set_property(TARGET example PROPERTY CXX_STANDARD 11)
+target_link_libraries(example ${CONAN_LIBS})
+
+# CTest is a testing tool that can be used to test your project.
+# enable_testing()
+# add_test(NAME example
+#          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+#          COMMAND example)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,22 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class CeleroTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is in "test_package"
+        cmake.configure()
+        cmake.build()
+
+    def imports(self):
+        self.copy("*.dll", dst="bin", src="bin")
+        self.copy("*.dylib*", dst="bin", src="lib")
+        self.copy('*.so*', dst='bin', src='lib')
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            os.chdir("bin")
+            self.run(".%sexample" % os.sep)

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,0 +1,3 @@
+#include <celero/Celero.h>
+
+CELERO_MAIN


### PR DESCRIPTION
With `conan` installed locally, you can use `conan create . <user>/<channel>` to make a conan package of Celero v2.1.1. 

I advise joining https://bintray.com/conan-community then `conan upload Celero/2.1.1@<user>/<channel> -r conan-community --all` 
